### PR TITLE
Exit with error if not all frameworks were built.

### DIFF
--- a/build_xcframeworks.sh
+++ b/build_xcframeworks.sh
@@ -88,7 +88,10 @@ function zipXCFramework () {
 
     pushd archives
     header "Zipping xcframework for $lib"
-    zip $lib.xcframework.zip $lib.xcframework -r
+    if ! zip $lib.xcframework.zip $lib.xcframework -r; then
+        echo "Error: $lib.xcframework not found or zip failed."
+        exit 1
+    fi
     popd
 }
 


### PR DESCRIPTION
 That could happen for instance when building for VisionOS if VisionOS SDK was not installed in Xcode