### PR TITLE
Renaming binary target to eliminate naming conflict

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
             path:"archives/SalesforceSDKCore.xcframework.zip"
         ),
         .binaryTarget(
-            name: "SmartStore",
+            name: "SmartStoreBinary",
             path:"archives/SmartStore.xcframework.zip"
         ),
         .binaryTarget(
@@ -60,7 +60,7 @@ let package = Package(
         .target(
             name: "SmartStoreWrapper",
             dependencies: [
-                "SmartStore",
+                "SmartStoreBinary",
                 .product(name: "SQLCipher", package: "SQLCipher.swift"),
                 .product(name: "FMDB", package: "fmdb")
             ]


### PR DESCRIPTION
That should allow https://github.com/forcedotcom/SalesforceMobileSDK-Package/actions/runs/17476386624/job/49729739865?pr=313 to pass.