### PR TITLE
Pointing to tag otherwise tagged SPM won't work 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sqlcipher/SQLCipher.swift.git", exact: "4.10.0"),
-        .package(url: "https://github.com/forcedotcom/fmdb.git", branch: "spm")
+        .package(url: "https://github.com/forcedotcom/fmdb.git", exact: "2.7.12-sqlcipher")
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
## Can't have unstable requirement in a package declared at a stable tag.

### Repro steps
Do a dry run of releasing Mobile SDK 13.1:
- run ./release/setup_test_branches.js (in fork to create master2/dev2)
- run ./release/release.js (in fork into master2/dev2)

Then try and generate an app from the iOSNativeSwiftPackageManager template.
The generated app will not compile with the following error:

```
!FAILURE! COMPILING native_swift app for ios based on template iOSNativeSwiftPackageManagerTemplate (v13.1.0)
Command failed: xcodebuild -project /Users/wmathurin/Development/github/wmathurin/SalesforceMobileSDK-Package/test131/SalesforceMobileSDK-Package/tmp20250910T143442.132/iosnativeswiftpackagemanager/iosnativeswiftpackagemanager.xcodeproj -scheme iosnativeswiftpackagemanager clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -destination generic/platform=iOS
2025-09-10 14:35:25.926 xcodebuild[83900:57448814] Writing error result bundle to /var/folders/jb/22vx628x5y7csq83bg0l5m8m0000gp/T/ResultBundle_2025-10-09_14-35-0025.xcresult
xcodebuild: error: Could not resolve package dependencies:
Failed to resolve dependencies Dependencies could not be resolved because package 'salesforcemobilesdk-ios-spm' is required using a stable-version but 'salesforcemobilesdk-ios-spm' depends on an unstable-version package 'fmdb' and root depends on 'salesforcemobilesdk-ios-spm' 13.1.0.
```

### Solution
That means we need to tag FMDB also and point to a tag in SalesforceMobileSDK-iOS-SPM's Package.swift
I create the tag on FMDB: https://github.com/forcedotcom/fmdb/releases/tag/2.7.12-sqlcipher