### PR TITLE
Add Mac Catalyst support to SPM XCFrameworks 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,6 @@ let package = Package(
     defaultLocalization: "en",
     platforms: [
         .iOS(.v18),
-        .watchOS(.v8),
         .visionOS(.v2),
         .macCatalyst(.v13)
     ],

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ This package supports:
 | Platform | Minimum Version |
 |----------|----------------|
 | **iOS** | 18.0 |
-| **watchOS** | 8.0 |
 | **visionOS** | 2.0 |
 | **macCatalyst** | 13.0 |
 
@@ -118,6 +117,9 @@ This repository contains:
 Each XCFramework includes slices for:
 - **iOS Devices**: arm64 (iPhone, iPad)
 - **iOS Simulator**: arm64 (Apple Silicon Macs) + x86_64 (Intel Macs)
+- **Mac Catalyst**: arm64 + x86_64 (native Mac apps)
+- **visionOS Device**: arm64 (Apple Vision Pro)
+- **visionOS Simulator**: arm64 (Apple Silicon Macs only)
 
 ## Binary vs Source Distribution
 

--- a/build_xcframeworks.sh
+++ b/build_xcframeworks.sh
@@ -50,29 +50,16 @@ function buildFramework() {
     local lib=$1
     local destination=$2
     local suffix=$3
-    local archs="${4:-}"
 
     pushd SalesforceMobileSDK-iOS
     header "Building $destination archive for $lib"
-
-    if [ -n "$archs" ]; then
-        xcodebuild archive \
-            -workspace SalesforceMobileSDK.xcworkspace \
-            -scheme $lib \
-            -destination "generic/platform=$destination" \
-            -archivePath ../archives/$lib-$suffix \
-            SKIP_INSTALL=NO \
-            BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-            ARCHS="$archs"
-    else
-        xcodebuild archive \
-            -workspace SalesforceMobileSDK.xcworkspace \
-            -scheme $lib \
-            -destination "generic/platform=$destination" \
-            -archivePath ../archives/$lib-$suffix \
-            SKIP_INSTALL=NO \
-            BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-    fi
+    xcodebuild archive \
+        -workspace SalesforceMobileSDK.xcworkspace \
+        -scheme $lib \
+        -destination "generic/platform=$destination" \
+        -archivePath ../archives/$lib-$suffix \
+        SKIP_INSTALL=NO \
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES
     popd
 
     if [ $lib == "SmartStore" ]
@@ -124,7 +111,7 @@ function processLib () {
     buildFramework $lib "iOS Simulator" "Sim"
     buildFramework $lib "macOS,variant=Mac Catalyst" "Catalyst"
     buildFramework $lib "visionOS" "visionOS"
-    buildFramework $lib "visionOS Simulator" "visionOS-Sim" "arm64"
+    buildFramework $lib "visionOS Simulator" "visionOS-Sim"
     buildXCFramework $lib
     zipXCFramework $lib
     # Using path instead of url / checksum in Package.swift - so checksum calculation is not needed

--- a/build_xcframeworks.sh
+++ b/build_xcframeworks.sh
@@ -50,16 +50,29 @@ function buildFramework() {
     local lib=$1
     local destination=$2
     local suffix=$3
+    local archs="${4:-}"
 
     pushd SalesforceMobileSDK-iOS
     header "Building $destination archive for $lib"
-    xcodebuild archive \
-        -workspace SalesforceMobileSDK.xcworkspace \
-        -scheme $lib \
-        -destination "generic/platform=$destination" \
-        -archivePath ../archives/$lib-$suffix \
-        SKIP_INSTALL=NO \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+    if [ -n "$archs" ]; then
+        xcodebuild archive \
+            -workspace SalesforceMobileSDK.xcworkspace \
+            -scheme $lib \
+            -destination "generic/platform=$destination" \
+            -archivePath ../archives/$lib-$suffix \
+            SKIP_INSTALL=NO \
+            BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+            ARCHS="$archs"
+    else
+        xcodebuild archive \
+            -workspace SalesforceMobileSDK.xcworkspace \
+            -scheme $lib \
+            -destination "generic/platform=$destination" \
+            -archivePath ../archives/$lib-$suffix \
+            SKIP_INSTALL=NO \
+            BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    fi
     popd
 
     if [ $lib == "SmartStore" ]
@@ -111,7 +124,7 @@ function processLib () {
     buildFramework $lib "iOS Simulator" "Sim"
     buildFramework $lib "macOS,variant=Mac Catalyst" "Catalyst"
     buildFramework $lib "visionOS" "visionOS"
-    buildFramework $lib "visionOS Simulator" "visionOS-Sim"
+    buildFramework $lib "visionOS Simulator" "visionOS-Sim" "arm64"
     buildXCFramework $lib
     zipXCFramework $lib
     # Using path instead of url / checksum in Package.swift - so checksum calculation is not needed

--- a/build_xcframeworks.sh
+++ b/build_xcframeworks.sh
@@ -77,6 +77,7 @@ function buildXCFramework () {
     xcodebuild -create-xcframework \
         -framework ../archives/$lib-iOS.xcarchive/Products/Library/Frameworks/$lib.framework \
         -framework ../archives/$lib-Sim.xcarchive/Products/Library/Frameworks/$lib.framework \
+        -framework ../archives/$lib-Catalyst.xcarchive/Products/Library/Frameworks/$lib.framework \
         -framework ../archives/$lib-visionOS.xcarchive/Products/Library/Frameworks/$lib.framework \
         -framework ../archives/$lib-visionOS-Sim.xcarchive/Products/Library/Frameworks/$lib.framework \
         -output ../archives/$lib.xcframework
@@ -108,6 +109,7 @@ function processLib () {
 
     buildFramework $lib "iOS" "iOS"
     buildFramework $lib "iOS Simulator" "Sim"
+    buildFramework $lib "macOS,variant=Mac Catalyst" "Catalyst"
     buildFramework $lib "visionOS" "visionOS"
     buildFramework $lib "visionOS Simulator" "visionOS-Sim"
     buildXCFramework $lib


### PR DESCRIPTION
## Summary

Adds Mac Catalyst support to the Swift Package Manager XCFramework distribution. Mac Catalyst builds now work
correctly without the `SmartStore.SmartStore` naming collision error that occurred with Xcode 26.3.

## Problem

When building iOS SDK projects targeting Mac Catalyst with Xcode 26.3+, compilation failed with:
'SmartStore' is not a member type of class 'SmartStore.SmartStore'
failed to build module 'SmartStore' for importation

Additionally, the SPM XCFrameworks did not include Mac Catalyst slices, preventing Mac Catalyst support
entirely.

## Changes

### 1. **build_xcframeworks.sh**
- Added Mac Catalyst build destination: `"macOS,variant=Mac Catalyst"`
- Included Catalyst framework in XCFramework creation
- Existing swiftinterface fix automatically applied to Catalyst builds

### 2. **Package.swift**
- Removed `.watchOS(.v8)` from supported platforms (XCFrameworks don't include watchOS slices)
- Kept `.macCatalyst(.v13)` unchanged

### 3. **README.md**
- Removed watchOS from Platform Support table
- Added Mac Catalyst, visionOS Device, and visionOS Simulator to Architecture Support section
- Clarified visionOS Simulator is Apple Silicon only

### 4. **XCFramework Archives**
All 5 archives rebuilt with Mac Catalyst support:
- SalesforceAnalytics: 215KB → 412KB
- SalesforceSDKCommon: 538KB → 1.0MB
- SalesforceSDKCore: 8.4MB → 16MB
- SmartStore: 1.0MB → 1.9MB
- MobileSync: 1.8MB → 3.5MB

## Testing

✅ **Mac Catalyst build**: Successfully built `SalesforceMobileSDK-Package` scheme for Mac Catalyst
- No `SmartStore.SmartStore` naming collision errors


