### PR TITLE
W-22921779: Revert master to 13.2.1 state and document dev branch model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,21 @@ git push origin 13.2.0
 
 **Important**: SPM uses tags without 'v' prefix (e.g., `13.2.0`, not `v13.2.0`).
 
+## Branch Model
+
+This repo follows the same two-branch model as all other Mobile SDK repos:
+
+- **`master`** — stable, tagged release snapshots only. Never commit work-in-progress here.
+- **`dev`** — active development for the next release. All changes targeting the next major/minor version land here.
+
+At release time, `release.js` in the Package repo:
+1. Merges `dev → master`
+2. Runs `build_xcframeworks.sh` on merged master
+3. Commits, tags master (no `v` prefix), pushes
+4. Merges `master → dev` and pushes dev
+
+For patch releases, `dev → master` merge is skipped; changes are cherry-picked directly to master.
+
 ### 6. Verify Release
 - Check that tag is visible on GitHub
 - Test in a new Xcode project by adding package via URL

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ let package = Package(
     name: "SalesforceMobileSDK",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v18),
+        .iOS(.v17),
+        .watchOS(.v8),
         .visionOS(.v2),
         .macCatalyst(.v13)
     ],
@@ -32,7 +33,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/sqlcipher/SQLCipher.swift.git", exact: "4.16.0"),
+        .package(url: "https://github.com/sqlcipher/SQLCipher.swift.git", exact: "4.10.0"),
         .package(url: "https://github.com/forcedotcom/fmdb.git", exact: "2.7.12-sqlcipher")
     ],
     targets: [
@@ -65,5 +66,5 @@ let package = Package(
             ]
         )
     ],
-    swiftLanguageModes: [.v5]
+    swiftLanguageVersions: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository provides **pre-built binary frameworks** (XCFrameworks) for the 
    ```
    https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM.git
    ```
-3. Select version or branch (e.g., `13.2.0` or `master`)
+3. Select version or branch (e.g., `13.2.1` or `master`)
 4. Choose which libraries to add to your target:
    - **SalesforceAnalytics** - Telemetry and analytics
    - **SalesforceSDKCommon** - Shared utilities
@@ -67,7 +67,8 @@ This package supports:
 
 | Platform | Minimum Version |
 |----------|----------------|
-| **iOS** | 18.0 |
+| **iOS** | 17.0 |
+| **watchOS** | 8.0 |
 | **visionOS** | 2.0 |
 | **macCatalyst** | 13.0 |
 
@@ -153,7 +154,7 @@ See [release notes](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/relea
 ## Dependencies
 
 This package automatically includes:
-- **SQLCipher**: 4.10.0 - SQLite encryption (for SmartStore)
+- **SQLCipher**: 4.10.0 (13.x) / 4.16.0 (14.x) - SQLite encryption (for SmartStore)
 - **FMDB**: 2.7.12-sqlcipher - Objective-C SQLite wrapper
 
 These are managed automatically by Swift Package Manager.
@@ -177,27 +178,32 @@ These are managed automatically by Swift Package Manager.
 
 ## For SDK Maintainers
 
+### Branch Model
+
+This repo follows the same two-branch workflow as all other Mobile SDK repos:
+
+- **`master`** — stable, tagged release snapshots only
+- **`dev`** — active development for the next release
+
+At release time, `release.js` in the Package repo merges `dev → master`, builds xcframeworks, commits, tags, then merges `master → dev`. For patch releases, changes are cherry-picked directly to master (no dev merge).
+
 ### Building XCFrameworks
 
-If you're a maintainer publishing a new release:
+XCFramework builds are automated by `release.js`. To build manually:
 
 ```bash
-# Clone this repository
-git clone https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM.git
-cd SalesforceMobileSDK-iOS-SPM
+# Build XCFrameworks from iOS SDK release tag
+./build_xcframeworks.sh -r forcedotcom -b master
 
-# Build XCFrameworks from iOS SDK release
-./build_xcframeworks.sh -r forcedotcom -b v13.2.0
-
-# Commit and tag
+# Commit and tag (release.js does this automatically)
 git add archives/ Package.swift
-git commit -m "Release v13.2.0"
-git tag 13.2.0  # Note: no 'v' prefix for SPM tags
+git commit -m "Mobile SDK 13.2.1"
+git tag 13.2.1  # Note: no 'v' prefix for SPM tags
 git push origin master
-git push origin 13.2.0
+git push origin 13.2.1
 ```
 
-**Important**: SPM tags should NOT have a 'v' prefix (e.g., use `13.2.0`, not `v13.2.0`).
+**Important**: SPM tags must NOT have a `v` prefix (e.g., use `13.2.1`, not `v13.2.1`).
 
 ## Related Repositories
 

--- a/build_xcframeworks.sh
+++ b/build_xcframeworks.sh
@@ -77,7 +77,6 @@ function buildXCFramework () {
     xcodebuild -create-xcframework \
         -framework ../archives/$lib-iOS.xcarchive/Products/Library/Frameworks/$lib.framework \
         -framework ../archives/$lib-Sim.xcarchive/Products/Library/Frameworks/$lib.framework \
-        -framework ../archives/$lib-Catalyst.xcarchive/Products/Library/Frameworks/$lib.framework \
         -framework ../archives/$lib-visionOS.xcarchive/Products/Library/Frameworks/$lib.framework \
         -framework ../archives/$lib-visionOS-Sim.xcarchive/Products/Library/Frameworks/$lib.framework \
         -output ../archives/$lib.xcframework
@@ -109,7 +108,6 @@ function processLib () {
 
     buildFramework $lib "iOS" "iOS"
     buildFramework $lib "iOS Simulator" "Sim"
-    buildFramework $lib "macOS,variant=Mac Catalyst" "Catalyst"
     buildFramework $lib "visionOS" "visionOS"
     buildFramework $lib "visionOS Simulator" "visionOS-Sim"
     buildXCFramework $lib


### PR DESCRIPTION
## Summary

Brings `master` back to the correct 13.2.1-era baseline and documents the new two-branch model.

## Context

During the 13.2.1 patch release, commit `2491921` reverted 14.0-era changes (iOS 18, SQLCipher 4.16, Catalyst build support, `swiftLanguageModes`) so the patch tag could be cut cleanly. Then commit `2ae7de8` re-applied them afterward. This revert/re-apply cycle was necessary because `master` was the only branch — there was nowhere else to put next-release work.

Now that a `dev` branch exists (see companion PR #21 targeting `dev`), `master` should stay at 13.x state and 14.0-era changes live on `dev`. This PR performs that cleanup.

## Changes

**Reverts commit `2ae7de8`** (the revert-of-revert), bringing master back to 13.2.1 state:

- `Package.swift`: `iOS(.v18)` → `iOS(.v17)` + `watchOS(.v8)`; SQLCipher `4.16.0` → `4.10.0`; `swiftLanguageModes` → `swiftLanguageVersions`
- `build_xcframeworks.sh`: removes Catalyst slice (`macOS,variant=Mac Catalyst`)

**`CLAUDE.md`**: adds Branch Model section documenting the two-branch workflow.

**`README.md`**: updates platform table (iOS 17, adds watchOS 8), updates maintainer build section, adds branch model note.

## ⚠️ Required follow-up after this PR merges

After this PR merges, **merge `master → dev` keeping dev's versions**:

```bash
git checkout dev
git merge -Xours master   # conflict on Package.swift and build_xcframeworks.sh — -Xours keeps dev's 14.0 values
git push origin dev
git push upstream dev
```

This is necessary because `release.js` uses `git merge -Xours` when merging `dev → master` at release time — meaning conflicts favour master. Without this merge-back, the common ancestor between `master` and `dev` is a commit that has 14.0 values, so the revert on master looks like a "change" that `-Xours` would keep, silently discarding the 14.0 changes from `dev`.

After the merge-back, the common ancestor becomes the reverted (13.x) master, and `dev` cleanly has the 14.0 changes on top — no conflict at release time.

## Companion PRs

- PR #21 → `dev`: docs update for the new branch model