### PR TITLE
W-22921779: Document dev branch model on dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository provides **pre-built binary frameworks** (XCFrameworks) for the 
    ```
    https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM.git
    ```
-3. Select version or branch (e.g., `13.2.0` or `master`)
+3. Select version or branch (e.g., `14.0.0` or `dev`)
 4. Choose which libraries to add to your target:
    - **SalesforceAnalytics** - Telemetry and analytics
    - **SalesforceSDKCommon** - Shared utilities
@@ -70,6 +70,8 @@ This package supports:
 | **iOS** | 18.0 |
 | **visionOS** | 2.0 |
 | **macCatalyst** | 13.0 |
+
+> **Note**: This is the `dev` branch, targeting the next release (14.0). For the current stable release see `master`.
 
 ## Usage Example
 
@@ -153,7 +155,7 @@ See [release notes](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/relea
 ## Dependencies
 
 This package automatically includes:
-- **SQLCipher**: 4.10.0 - SQLite encryption (for SmartStore)
+- **SQLCipher**: 4.16.0 - SQLite encryption (for SmartStore)
 - **FMDB**: 2.7.12-sqlcipher - Objective-C SQLite wrapper
 
 These are managed automatically by Swift Package Manager.
@@ -177,27 +179,32 @@ These are managed automatically by Swift Package Manager.
 
 ## For SDK Maintainers
 
+### Branch Model
+
+This repo follows the same two-branch workflow as all other Mobile SDK repos:
+
+- **`master`** — stable, tagged release snapshots only
+- **`dev`** — active development for the next release (this branch)
+
+At release time, `release.js` in the Package repo merges `dev → master`, builds xcframeworks, commits, tags, then merges `master → dev`. For patch releases, changes are cherry-picked directly to master (no dev merge).
+
 ### Building XCFrameworks
 
-If you're a maintainer publishing a new release:
+XCFramework builds are automated by `release.js`. To build manually:
 
 ```bash
-# Clone this repository
-git clone https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM.git
-cd SalesforceMobileSDK-iOS-SPM
+# Build XCFrameworks from the current branch
+./build_xcframeworks.sh -r forcedotcom -b master
 
-# Build XCFrameworks from iOS SDK release
-./build_xcframeworks.sh -r forcedotcom -b v13.2.0
-
-# Commit and tag
+# Commit and tag (release.js does this automatically)
 git add archives/ Package.swift
-git commit -m "Release v13.2.0"
-git tag 13.2.0  # Note: no 'v' prefix for SPM tags
+git commit -m "Mobile SDK 14.0.0"
+git tag 14.0.0  # Note: no 'v' prefix for SPM tags
 git push origin master
-git push origin 13.2.0
+git push origin 14.0.0
 ```
 
-**Important**: SPM tags should NOT have a 'v' prefix (e.g., use `13.2.0`, not `v13.2.0`).
+**Important**: SPM tags must NOT have a `v` prefix (e.g., use `14.0.0`, not `v14.0.0`).
 
 ## Related Repositories
 


### PR DESCRIPTION
## Summary

Documentation-only update for the new `dev` branch. No code changes.

## Changes

**`README.md`**
- Version/branch examples updated to 14.0/dev
- Added dev branch note to platform support table
- Updated SQLCipher dependency to 4.16.0 (correct for 14.x)
- Replaced maintainer build section with branch model description

**`CLAUDE.md`**
- Added Branch Model section documenting the two-branch workflow and how `release.js` handles iOS-SPM at release time

## Context

Part of W-22921779. The companion PR #20 reverts `master` to 13.2.1 state. This PR documents what `dev` is for.

## Why no code changes in this PR

The 14.0-era changes (`iOS(.v18)`, SQLCipher 4.16.0, `swiftLanguageModes`, Catalyst build support) are already present on `dev`. The `dev` branch was created from the `master` HEAD that already contained those changes — they predate this PR and are part of the branch base, not introduced here.

## Merge order

Can merge alongside or after PR #20. The `dev` branch was pushed directly to `forcedotcom` and already contains the 14.0-era changes.